### PR TITLE
Add some spaces between parts of SQL statements.

### DIFF
--- a/pkg/mssqldb/permissions.go
+++ b/pkg/mssqldb/permissions.go
@@ -27,17 +27,17 @@ func (c *Client) ListServerPermissions(ctx context.Context, pager *Pager) ([]*Pe
 	args := []interface{}{offset, limit + 1}
 
 	var sb strings.Builder
-	_, _ = sb.WriteString(`SELECT
-principals.name as principal_name,
-perms.grantee_principal_id as principal_id,
-perms.state as state,
-STRING_AGG(perms.type, ',') as perms,
-principals.type as principal_type
-FROM sys.server_permissions perms
-         JOIN sys.server_principals principals ON perms.grantee_principal_id = principals.principal_id
-WHERE perms.state = 'G' OR perms.state = 'W'
-GROUP BY perms.grantee_principal_id, perms.state, principals.name, principals.type
-ORDER BY perms.grantee_principal_id ASC
+	_, _ = sb.WriteString(`SELECT 
+principals.name as principal_name, 
+perms.grantee_principal_id as principal_id, 
+perms.state as state, 
+STRING_AGG(perms.type, ',') as perms, 
+principals.type as principal_type 
+FROM sys.server_permissions perms 
+         JOIN sys.server_principals principals ON perms.grantee_principal_id = principals.principal_id 
+WHERE perms.state = 'G' OR perms.state = 'W' 
+GROUP BY perms.grantee_principal_id, perms.state, principals.name, principals.type 
+ORDER BY perms.grantee_principal_id ASC 
 OFFSET @p1 ROWS FETCH NEXT @p2 ROWS ONLY`)
 
 	rows, err := c.db.QueryxContext(ctx, sb.String(), args...)
@@ -91,11 +91,11 @@ FROM `)
 	_, _ = sb.WriteString(`.sys.database_permissions perms
          JOIN `)
 	_, _ = sb.WriteString(dbName)
-	_, _ = sb.WriteString(`.sys.database_principals AS principals
-             ON perms.grantee_principal_id = principals.principal_id
-WHERE (perms.state = 'G' OR perms.state = 'W') AND (perms.class = 0 AND perms.major_id = 0)
-GROUP BY perms.grantee_principal_id, perms.state, principals.name, principals.type
-ORDER BY perms.grantee_principal_id ASC
+	_, _ = sb.WriteString(`.sys.database_principals AS principals 
+             ON perms.grantee_principal_id = principals.principal_id 
+WHERE (perms.state = 'G' OR perms.state = 'W') AND (perms.class = 0 AND perms.major_id = 0) 
+GROUP BY perms.grantee_principal_id, perms.state, principals.name, principals.type 
+ORDER BY perms.grantee_principal_id ASC 
 OFFSET @p1 ROWS FETCH NEXT @p2 ROWS ONLY`)
 
 	rows, err := c.db.QueryxContext(ctx, sb.String(), args...)

--- a/pkg/mssqldb/roles.go
+++ b/pkg/mssqldb/roles.go
@@ -43,11 +43,11 @@ func (c *Client) ListServerRolePrincipals(ctx context.Context, serverRoleID stri
 SELECT 
   sys.server_principals.principal_id,
   sys.server_principals.name, 
-  sys.server_principals.type
+  sys.server_principals.type 
 FROM 
-  sys.server_principals
-JOIN sys.server_role_members ON sys.server_role_members.member_principal_id = sys.server_principals.principal_id
-WHERE sys.server_role_members.role_principal_id = @p1
+  sys.server_principals 
+JOIN sys.server_role_members ON sys.server_role_members.member_principal_id = sys.server_principals.principal_id 
+WHERE sys.server_role_members.role_principal_id = @p1 
 ORDER BY 
   sys.server_principals.principal_id ASC OFFSET @p2 ROWS FETCH NEXT @p3 ROWS ONLY
 `)
@@ -102,7 +102,7 @@ SELECT
   type_desc 
 FROM 
   sys.server_principals 
-WHERE type = 'R'
+WHERE type = 'R' 
 ORDER BY 
   principal_id ASC OFFSET @p1 ROWS FETCH NEXT @p2 ROWS ONLY
 `)
@@ -150,14 +150,14 @@ func (c *Client) ListDatabaseRoles(ctx context.Context, dbName string, pager *Pa
 	// Fetch the database role principals.
 	_, _ = sb.WriteString(`
 SELECT 
-  principal_id,
+  principal_id, 
   sid,
   name, 
   type_desc 
 FROM `)
 	_, _ = sb.WriteString(dbName)
 	_, _ = sb.WriteString(`.sys.database_principals 
-WHERE type = 'R'
+WHERE type = 'R' 
 ORDER BY 
   principal_id ASC OFFSET @p1 ROWS FETCH NEXT @p2 ROWS ONLY
 `)
@@ -202,14 +202,14 @@ func (c *Client) ListDatabaseRolePrincipals(ctx context.Context, dbName string, 
 	args := []interface{}{databaseRoleID, offset, limit + 1}
 
 	query := fmt.Sprintf(
-		`SELECT
+		`SELECT 
 	%s.sys.database_principals.principal_id,
 		%s.sys.database_principals.name,
 		%s.sys.database_principals.type
-		FROM
-	%s.sys.database_principals
-	JOIN %s.sys.database_role_members ON %s.sys.database_role_members.member_principal_id = %s.sys.database_principals.principal_id
-	WHERE %s.sys.database_role_members.role_principal_id = @p1
+		FROM 
+	%s.sys.database_principals 
+	JOIN %s.sys.database_role_members ON %s.sys.database_role_members.member_principal_id = %s.sys.database_principals.principal_id 
+	WHERE %s.sys.database_role_members.role_principal_id = @p1 
 	ORDER BY %s.sys.database_principals.principal_id ASC OFFSET @p2 ROWS FETCH NEXT @p3 ROWS ONLY`,
 		dbName,
 		dbName,


### PR DESCRIPTION
Some SQL statements have spaces between keywords. Some don't. It's suspicious that one of the ORDER BYs without spaces is breaking. I guess newlines aren't enough. Maybe they're getting stripped?