### PR TITLE
[BB-906] baton-sql-server: add user deprovisioning

### DIFF
--- a/pkg/connector/server_user.go
+++ b/pkg/connector/server_user.go
@@ -19,6 +19,8 @@ import (
 	"go.uber.org/zap"
 )
 
+var _ connectorbuilder.ResourceDeleter = (*userPrincipalSyncer)(nil)
+
 // userPrincipalSyncer implements both ResourceSyncer and AccountManager.
 type userPrincipalSyncer struct {
 	resourceType *v2.ResourceType
@@ -215,6 +217,19 @@ func (d *userPrincipalSyncer) CreateAccountCapabilityDetails(
 		},
 		PreferredCredentialOption: v2.CapabilityDetailCredentialOption_CAPABILITY_DETAIL_CREDENTIAL_OPTION_NO_PASSWORD,
 	}, nil, nil
+}
+
+func (d *userPrincipalSyncer) Delete(ctx context.Context, resourceId *v2.ResourceId) (annotations.Annotations, error) {
+	user, err := d.client.GetUserPrincipal(ctx, resourceId.GetResource())
+	if err != nil {
+		return nil, err
+	}
+
+	err = d.client.DisableUserFromServer(ctx, user.Name)
+	if err != nil {
+		return nil, err
+	}
+	return nil, err
 }
 
 // generateStrongPassword creates a secure random password for SQL Server.

--- a/pkg/connector/server_user.go
+++ b/pkg/connector/server_user.go
@@ -229,7 +229,7 @@ func (d *userPrincipalSyncer) Delete(ctx context.Context, resourceId *v2.Resourc
 	if err != nil {
 		return nil, err
 	}
-	return nil, err
+	return nil, nil
 }
 
 // generateStrongPassword creates a secure random password for SQL Server.

--- a/pkg/mssqldb/server.go
+++ b/pkg/mssqldb/server.go
@@ -2,6 +2,7 @@ package mssqldb
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
@@ -32,4 +33,15 @@ func (c *Client) GetServer(ctx context.Context) (*ServerModel, error) {
 	}
 
 	return &ret, nil
+}
+
+func (c *Client) DisableUserFromServer(ctx context.Context, userName string) error {
+	query := fmt.Sprintf(`
+ALTER LOGIN [%s] DISABLE;`, userName)
+
+	_, err := c.db.ExecContext(ctx, query)
+	if err != nil {
+		return err
+	}
+	return nil
 }

--- a/pkg/mssqldb/server.go
+++ b/pkg/mssqldb/server.go
@@ -36,6 +36,10 @@ func (c *Client) GetServer(ctx context.Context) (*ServerModel, error) {
 }
 
 func (c *Client) DisableUserFromServer(ctx context.Context, userName string) error {
+	if strings.ContainsAny(userName, "[]\"';") {
+		return fmt.Errorf("invalid characters in userName")
+	}
+
 	query := fmt.Sprintf(`
 ALTER LOGIN [%s] DISABLE;`, userName)
 


### PR DESCRIPTION
### Description.
Follow [doc](https://conductorone.atlassian.net/wiki/spaces/ENG/pages/2378334240/Account+Deprovisioning+Connector+Guide) to add account deprovisioning. 

As [BB-906] described, account deprovisioning could be `disable user login`, so `Delete()` function is used to disable user.

#### Test. 
1. Before account deprovisioning
<img width="1063" alt="image" src="https://github.com/user-attachments/assets/a2a420be-94df-4cb4-9bf9-d9ca04285850" />

2. Run the `delete command` 
<img width="1280" alt="image" src="https://github.com/user-attachments/assets/5873433b-260c-4fe9-be63-62be4307bbe8" />
3. Check if the user is diabled. 
<img width="1039" alt="image" src="https://github.com/user-attachments/assets/1982e2ea-9181-4cf4-863b-d09dc329f965" />


[BB-906]: https://conductorone.atlassian.net/browse/BB-906?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ