### PR TITLE
[BB-906] baton-sql-server: delete users when we do account deprovisioning.

### DIFF
--- a/pkg/connector/server_user.go
+++ b/pkg/connector/server_user.go
@@ -249,7 +249,7 @@ func (d *userPrincipalSyncer) Delete(ctx context.Context, resourceId *v2.Resourc
 		return nil, err
 	}
 
-	err = d.client.DisableUserFromServer(ctx, user.Name)
+	err = d.client.DeleteUserFromServer(ctx, user.Name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/mssqldb/server.go
+++ b/pkg/mssqldb/server.go
@@ -35,13 +35,13 @@ func (c *Client) GetServer(ctx context.Context) (*ServerModel, error) {
 	return &ret, nil
 }
 
-func (c *Client) DisableUserFromServer(ctx context.Context, userName string) error {
+func (c *Client) DeleteUserFromServer(ctx context.Context, userName string) error {
 	if strings.ContainsAny(userName, "[]\"';") {
 		return fmt.Errorf("invalid characters in userName")
 	}
 
 	query := fmt.Sprintf(`
-ALTER LOGIN [%s] DISABLE;`, userName)
+DROP LOGIN [%s];`, userName)
 
 	_, err := c.db.ExecContext(ctx, query)
 	if err != nil {


### PR DESCRIPTION
## Test
1. make first request.
<img width="912" alt="image" src="https://github.com/user-attachments/assets/6dd48bdc-f02c-4bfa-ad88-16d64778fec1" />
2. account deprovisioning.
<img width="925" alt="image" src="https://github.com/user-attachments/assets/71eb964b-588b-491d-a1e4-b1bbc3863584" />
3. make second request.
<img width="852" alt="image" src="https://github.com/user-attachments/assets/958600bf-b435-45d2-bc81-99dc79f9fca4" />
