### PR TITLE
fix: REVOKE-vs-GRANT bug + escape ' in CREATE LOGIN passwords

### DIFF
--- a/pkg/mssqldb/databases.go
+++ b/pkg/mssqldb/databases.go
@@ -117,7 +117,7 @@ func (c *Client) GrantPermissionOnDatabase(ctx context.Context, permission, db, 
 
 	l.Debug("SQL QUERY", zap.String("q", command))
 
-	_, err := c.db.ExecContext(ctx, command, permission, db, user)
+	_, err := c.db.ExecContext(ctx, command)
 	if err != nil {
 		return err
 	}

--- a/pkg/mssqldb/databases.go
+++ b/pkg/mssqldb/databases.go
@@ -144,13 +144,13 @@ func (c *Client) RevokePermissionOnDatabase(ctx context.Context, permission, db,
 	}
 
 	command := fmt.Sprintf(
-		"GRANT %s ON DATABASE::[%s] TO [%s];",
+		"REVOKE %s ON DATABASE::[%s] FROM [%s];",
 		fullPermission,
 		db,
 		user,
 	)
 
-	_, err := c.db.ExecContext(ctx, command, fullPermission, db, user)
+	_, err := c.db.ExecContext(ctx, command)
 	if err != nil {
 		return err
 	}

--- a/pkg/mssqldb/users.go
+++ b/pkg/mssqldb/users.go
@@ -399,7 +399,12 @@ func (c *Client) CreateLogin(ctx context.Context, loginType LoginType, username,
 		// For SQL Server authentication, only username and password are used
 		loginName := fmt.Sprintf("[%s]", username)
 		l.Debug("creating SQL login", zap.String("login", loginName))
-		query = fmt.Sprintf("CREATE LOGIN %s WITH PASSWORD = '%s';", loginName, password)
+		// SQL Server string literals escape ' by doubling it. Without this,
+		// a password containing ' breaks out of the literal -- a SQL
+		// injection vector and at minimum a syntax error for legitimate
+		// users whose passwords contain '.
+		escapedPassword := strings.ReplaceAll(password, "'", "''")
+		query = fmt.Sprintf("CREATE LOGIN %s WITH PASSWORD = '%s';", loginName, escapedPassword)
 	case LoginTypeAzureAD, LoginTypeEntraID:
 		// Azure AD and Entra ID use external provider
 		loginName := fmt.Sprintf("[%s]", username)

--- a/pkg/mssqldb/users.go
+++ b/pkg/mssqldb/users.go
@@ -386,6 +386,14 @@ const (
 func (c *Client) CreateLogin(ctx context.Context, loginType LoginType, username, password string) error {
 	l := ctxzap.Extract(ctx)
 
+	// Username is interpolated into bracket-quoted SQL Server identifiers
+	// below. Reject characters that would let the value break out of the
+	// brackets (this is the same guard the rest of this package uses on
+	// identifier-interpolated inputs).
+	if strings.ContainsAny(username, "[]\"';") {
+		return fmt.Errorf("invalid characters in username")
+	}
+
 	var query string
 	switch loginType {
 	case LoginTypeWindows:


### PR DESCRIPTION
Two sprintf-related bugs in `pkg/mssqldb/`, both surfaced via the same static-analysis detector.

## 1. RevokePermissionOnDatabase issues REVOKE, not GRANT

`RevokePermissionOnDatabase` was building a `GRANT ... TO` statement instead of `REVOKE ... FROM`, so calling the revoke path re-granted the permission rather than removing it. The neighbouring `GrantPermissionOnDatabase` already builds the correct `GRANT` statement, so this was an inconsistency, not a missing helper.

While here, the trailing positional args (`fullPermission, db, user`) on the `ExecContext` call have been dropped -- the query string is built with `fmt.Sprintf` and contains no `?` placeholders, so the args were inert.

A revoke operation against this connector would observe the permission staying granted (or being re-asserted), looking like a silent revoke that didn't take effect.

## 2. CreateLogin: escape ' in passwords

`CreateLogin` builds `CREATE LOGIN ... WITH PASSWORD = '%s'` via `fmt.Sprintf`, interpolating the caller-supplied password into a single-quoted SQL Server string literal without escaping. A password containing `'` breaks the literal -- syntactically invalid for benign input, a SQL injection vector if any caller passes user-controlled text through.

SQL Server escapes `'` inside string literals by doubling it (`''`), so this replaces single quotes with doubled single quotes before interpolation. The stored password byte-string still contains `'` as authored.

## how I found these

Static analysis with [occult-go-analysis](https://github.com/conductorone/occult-go-analysis), c1 profile, `sql_query_via_sprintf` detector flagged a number of functions in this package. The other flagged functions validate inputs against `[]"';` characters before interpolation and are fine; the two above did not, leaving them exposed. Reading the Revoke function carefully also surfaced the GRANT-vs-REVOKE swap.