### PR TITLE
fix: mark dsn as isSecret in config_schema

### DIFF
--- a/cmd/baton-sql-server/config.go
+++ b/cmd/baton-sql-server/config.go
@@ -7,7 +7,8 @@ import (
 var (
 	dsn = field.StringField("dsn",
 		field.WithDescription("The connection string for connecting to SQL Server"),
-		field.WithRequired(true))
+		field.WithRequired(true),
+		field.WithIsSecret(true))
 	skipUnavailableDatabases = field.BoolField("skip-unavailable-databases",
 		field.WithDescription("Skip databases that are unavailable (offline, restoring, etc)"))
 )


### PR DESCRIPTION
Marks the `dsn` field as a secret credential. The SQL Server connection string embeds authentication material (typically `user id`/`password`), so it must be treated as a secret; it was not flagged `isSecret`.

This connector defines its config in `cmd/baton-sql-server/config.go` and does not commit a root `config_schema.json`; the schema is generated from these field definitions, so adding `field.WithIsSecret(true)` is the equivalent fix (no committed `config_schema.json` to regenerate).

> BREAKING: adding `isSecret: true` to these fields changes how existing configurations are stored. Customers with existing connector configurations will need to re-enter credentials after this change is deployed.

Audit: connector-secret-audit-phase15. Do not merge without review.